### PR TITLE
fix: Support 'Take-home Assessment' column and fix case-sensitive fallback

### DIFF
--- a/run.py
+++ b/run.py
@@ -41,7 +41,10 @@ def retrieve_all_take_home_reviewers(database_id: str) -> List[str]:
     for result in results:
         properties = result.get('properties', {})
         columns = properties.get(
-            'Take-home Assignment', properties.get('Reviewer & Interviewer', {})
+            'Take-home Assessment',
+            properties.get(
+                'Take-home Assignment', properties.get('Reviewer & Interviewer', {})
+            ),
         )
         if not columns:
             continue
@@ -265,9 +268,9 @@ if __name__ == '__main__':
             mentions = f'<@{slack_user_id}> :adore-x5: '
         else:
             print(f'No reviewers found in Notion database for position: {position}')
-            if 'backend' in position:
+            if 'backend' in position.lower():
                 mentions = ' '.join(random.choice(back_backend_fallback_reviewer)) + ' :adore-x5: '
-            elif 'frontend' in position:
+            elif 'frontend' in position.lower():
                 mentions = ' '.join(random.choice(frontend_fallback_reviewer)) + ' :adore-x5: '
             else:
                 mentions = '`Engineers 404 NOT FOUND` :shock:'


### PR DESCRIPTION
## Summary
- Added support for 'Take-home Assessment' Notion column in `retrieve_all_take_home_reviewers()`
- Fixed case-sensitive fallback reviewer logic to properly match 'Frontend Engineer' and 'Backend Engineer' positions

## Changes
**Notion Column Support:**
- Updated `retrieve_all_take_home_reviewers()` to check for 'Take-home Assessment' as the first priority, followed by 'Take-home Assignment' and 'Reviewer & Interviewer'
- Aligns with the pattern already used in `get_notion_user_emails()`

**Case-Sensitivity Fix:**
- Changed fallback reviewer checks from `'frontend' in position` to `'frontend' in position.lower()`
- Ensures position strings like 'Frontend Engineer' (capitalized) are properly matched

## Test plan
- [ ] Verify reviewers are retrieved correctly when using 'Take-home Assessment' column in Notion
- [ ] Test fallback logic with various position formats (e.g., 'Frontend Engineer', 'Backend Engineer')

🤖 Generated with [Claude Code](https://claude.com/claude-code)